### PR TITLE
refactor: remove state dependencies on useApi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 # generated file 
 projectCode.txt
 generated_comments.md
+.idea

--- a/hooks/useApi.js
+++ b/hooks/useApi.js
@@ -1,45 +1,75 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
-const useApi = (url, method, payload) => {
+const useApi = () => {
 
   const [data, setData] = useState();
   const [error, setError] = useState();
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      try {
-        const response = await fetch(url, {
-          method,
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ payload }),
-        });
 
-        const result = await response.json();
-        if (response.status !== 200) {
-          throw (
+
+  const fetchData = useCallback(async (url, method, payload) => {
+    setLoading(true);
+    try {
+      const response = await fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ payload }),
+      });
+
+      const result = await response.json();
+      if (response.status !== 200) {
+        throw (
             result.error ||
             new Error(`Request failed with status ${response.status}`)
-          );
-        }
-
-        setData(result);
-        setError(null);
-      } catch (error) {
-        setError(error);
-      } finally {
-        setLoading(false);
+        );
       }
-    };
-    if (payload) {
-      fetchData(); 
-    }
-  }, [url, method, payload]);
 
-  return { data, error, loading };
+      setData(result);
+      setError(null);
+    } catch (error) {
+      setError(error);
+    } finally {
+      setLoading(false);
+    }
+  },[]);
+
+  // useEffect(() => {
+  //   const fetchData = async () => {
+  //     setLoading(true);
+  //     try {
+  //       const response = await fetch(url, {
+  //         method,
+  //         headers: {
+  //           "Content-Type": "application/json",
+  //         },
+  //         body: JSON.stringify({ payload }),
+  //       });
+  //
+  //       const result = await response.json();
+  //       if (response.status !== 200) {
+  //         throw (
+  //           result.error ||
+  //           new Error(`Request failed with status ${response.status}`)
+  //         );
+  //       }
+  //
+  //       setData(result);
+  //       setError(null);
+  //     } catch (error) {
+  //       setError(error);
+  //     } finally {
+  //       setLoading(false);
+  //     }
+  //   };
+  //   if (payload) {
+  //     fetchData();
+  //   }
+  // }, [url, method, payload]);
+
+  return { data, error, loading, fetchData };
 };
 
 export default useApi;

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,16 +13,16 @@ const inter = Inter({ subsets: ["latin"] });
 
 export default function Home() {
   const [inputValue, setInputValue] = useState("");
-  const [submitValue, setSubmitValue] = useState("");
-  const { data, error, loading } = useApi("/api/openai", "POST", submitValue);
+  const { data, error, loading, fetchData } = useApi();
 
   const handleInputChange = (event) => {
     event.preventDefault();
     setInputValue(event.target.value);
   };
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
-    setSubmitValue(getUserPrompt(inputValue));
+    const submitValue = getUserPrompt(inputValue);
+    await fetchData("/api/openai", "POST", submitValue)
   };
   const handleKeyPress = (event) => {
     if (event.key === "Enter") {


### PR DESCRIPTION
Generally when we are talking about state management in react, we want the children to propagate state changes to the parent, so the parent can decide what to do with them. Since we are calling the useApi in the page, it's best to expose its state.